### PR TITLE
Add vendor js task

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -3,6 +3,7 @@ module.exports = {
   js: {
     watch: ["./src/assets/js/**/*.js", "./src/assets/js/templates/**/*.html", "!./src/assets/js/vendor/**/*.js", "./test/**/*.js"],
     build: ["./src/assets/js/*.js"],
+    vendor: ["./src/assets/js/vendor/*.js"],
     test: ["./test/**/*.js"],
     dest: "./dist/js"
   },

--- a/lib/tasks-js.js
+++ b/lib/tasks-js.js
@@ -27,7 +27,7 @@ module.exports = function () {
     var templateTransform = underscorify.transform({
       extensions: ['html']
     });
-    
+
     return gulp.src(paths.js.build)
 
       .pipe(gulpif(argv.production, rename(rev)))
@@ -52,6 +52,19 @@ module.exports = function () {
 
   });
 
+
+  /**
+   * Move 3rd-party vendor JS files to dist
+   * without attempting to compile or browserify
+   *
+   */
+  gulp.task("move:vendorjs", ["remove:js"], function () {
+    return gulp.src(paths.js.vendor)
+      .pipe(gulp.dest(paths.js.dest));
+  });
+
+
+
   gulp.task("test:js", function () {
     gulp.src(paths.js.test)
       .pipe(mocha({reporter: "spec"}))
@@ -61,8 +74,8 @@ module.exports = function () {
       });
   });
 
-  gulp.task("watch", ["compile:js", "test:js"], function () {
-    gulp.watch(paths.js.watch, ["compile:js", "test:js"]);
+  gulp.task("watch", ["compile:js", "move:vendorjs", "test:js"], function () {
+    gulp.watch(paths.js.watch, ["compile:js", "move:vendorjs", "test:js"]);
   });
 
   return gulp.tasks;


### PR DESCRIPTION
Needed the JS tasks to also allow for 3rd party vendor files to be moved to dist without being browserified or anything else. This task does that and puts it into the watch flow correctly.
