### PR TITLE
Add paths to export to give access

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,9 @@ var getTask = {
   release: require("./lib/tasks-release")
 };
 
-var taskTypes = function () {};
+var taskTypes = function () {
+  this.paths = paths;
+};
 
 taskTypes.prototype.php = function () {
   return _.extend(getTask.php(), getTask.release());
@@ -45,7 +47,7 @@ taskTypes.prototype.jsapp = function () {
 };
 
 taskTypes.prototype.wptheme = function () {
-  
+
   gulp.tasks = _.extend(getTask.js(), getTask.css(), getTask.images(), getTask.wptheme(), getTask.php(), getTask.release());
 
   gulp.task("watch", ["compile:js", "compile:css", "move:images", "phpunit", "compile:themefiles"], function () {


### PR DESCRIPTION
Now you should be able to do

``` js
var tasks = require("gulp-tasks");
var paths = tasks.paths;

gulp.task('custom', function () {
  return gulp.src(paths.js.vendor).pipe(gulp.dest(paths.js.dest));
});
```
