### PR TITLE
Add vendor task to wptheme taskset

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,10 @@ taskTypes.prototype.wpplugin = function () {
 
   gulp.tasks = _.extend(getTask.js(), getTask.css(), getTask.images(), getTask.php(), getTask.release());
 
-  gulp.task("watch", ["compile:js", "compile:css", "move:images", "phpunit"], function () {
-    gulp.watch(paths.js.watch, ["compile:js"]);
+  gulp.task("default", ["compile:js", "move:vendorjs", "compile:css", "move:images", "phpunit"]);
+
+  gulp.task("watch", ["default"], function () {
+    gulp.watch(paths.js.watch, ["compile:js", "move:vendorjs"]);
     gulp.watch(paths.css.watch, ["compile:css"]);
     gulp.watch(paths.images.watch, ["move:images"]);
     gulp.watch(paths.php.watch, ["phpunit"]);


### PR DESCRIPTION
Add my new vendor task to wptheme task, and use default task that watch task depends on now instead of putting all deps on watch. Now you can run `gulp` and get the same effect as first run of `gulp watch`
